### PR TITLE
patriotchronicle.com added

### DIFF
--- a/ext/src/inject/inject.js
+++ b/ext/src/inject/inject.js
@@ -220,6 +220,7 @@ chrome.extension.sendMessage({}, function(response) {
 			'openmindmagazine.com',
 			'other98.com',
 			'pakalertpress.com',
+			'patriotchronicle.com',
 			'politicalblindspot.com',
 			'politicalears.com',
 			'politicalo.com',


### PR DESCRIPTION
I added the patriotchronicle.com to your list of sites.

The patriotchronicle.com is a wordpress fake news site that floats around Facebook.  Here's an example of [some of its content](https://www.google.com/search?client=ubuntu&channel=fs&q=patriotchronicle.com+credibility&ie=utf-8&oe=utf-8) which was thoroughly [debunked by snopes](http://www.snopes.com/obama-salute-marine-one-video/).  And [another example](http://www.patriotchronicle.com/obama-skipped-almost-60-daily-intelligence-briefings-wonder-fight-isis-going-poorly/) which was [debunked by the Washington Post](https://www.washingtonpost.com/blogs/fact-checker/post/the-bogus-claim-that-obama-skips-his-intelligence-briefings/2012/09/22/100cb63e-04fc-11e2-8102-ebee9c66e190_blog.html)