### PR TITLE
Added facebook interface

### DIFF
--- a/ext/src/inject/inject.css
+++ b/ext/src/inject/inject.css
@@ -1,6 +1,13 @@
 /**
  * Place your custom CSS styles here.
  **/
+div.fakeNews{
+  background: rgba(255, 00, 00, .5);
+  color: white;
+  font-weight: bold;
+  text-align: center;
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
 [class*="hint--"] {
-  
 }

--- a/ext/src/inject/inject.js
+++ b/ext/src/inject/inject.js
@@ -383,9 +383,18 @@ chrome.extension.sendMessage({}, function(response) {
 		linkWarning = function() {
 			$.each(links, function(index, url) {
 				var badLink = 'a[href*="' + url + '"]';
+				var warnClass = "hint--error hint--large hint--bottom";
+				var warnMessage = 'This website is considered a questionable source.';
 				$(badLink).each(function() {
-					$(this).addClass('hint--error hint--large hint--bottom');
+					$(this).addClass("hint--error hint--large hint--bottom");
 					$(this).attr('aria-label', 'This website is considered a questionable source.');
+					if(window.location.hostname == "www.facebook.com"){
+						theWrapper = $(this).closest('div.userContentWrapper');
+						if(!theWrapper.hasClass('fFlagged')){
+							theWrapper.find('div.userContent').after('<div class="fakeNews">This website is considered a questionable source.<div>');
+							theWrapper.addClass('fFlagged');
+						}
+					}
 				});
 			});
 		};

--- a/ext/src/inject/inject.js
+++ b/ext/src/inject/inject.js
@@ -383,15 +383,14 @@ chrome.extension.sendMessage({}, function(response) {
 		linkWarning = function() {
 			$.each(links, function(index, url) {
 				var badLink = 'a[href*="' + url + '"]';
-				var warnClass = "hint--error hint--large hint--bottom";
-				var warnMessage = 'This website is considered a questionable source.';
+				var warnMessage = 'This website is not a reliable news source.';
 				$(badLink).each(function() {
 					$(this).addClass("hint--error hint--large hint--bottom");
-					$(this).attr('aria-label', 'This website is considered a questionable source.');
+					$(this).attr('aria-label', warnMessage);
 					if(window.location.hostname == "www.facebook.com"){
 						theWrapper = $(this).closest('div.userContentWrapper');
 						if(!theWrapper.hasClass('fFlagged')){
-							theWrapper.find('div.userContent').after('<div class="fakeNews">This website is considered a questionable source.<div>');
+							theWrapper.find('div.userContent').after('<div class="fakeNews">'+warnMessage+'<div>');
 							theWrapper.addClass('fFlagged');
 						}
 					}

--- a/ext/src/inject/inject.js
+++ b/ext/src/inject/inject.js
@@ -380,7 +380,7 @@ chrome.extension.sendMessage({}, function(response) {
 			'zaytung.com'
 		];
 
-		function linkWarning() {
+		linkWarning = function() {
 			$.each(links, function(index, url) {
 				var badLink = 'a[href*="' + url + '"]';
 				$(badLink).each(function() {
@@ -389,7 +389,6 @@ chrome.extension.sendMessage({}, function(response) {
 				});
 			});
 		};
-		linkWarning();
 
 		$(window).scroll(function() {
 			linkWarning();


### PR DESCRIPTION
I added a custom interface for Facebook articles.  The idea is that most people just read the headlines and often don't even mouse over the content that they take in.  I've added a separate textbox above the article with a warning.  The mockup is below.
![facebookinterface1](https://cloud.githubusercontent.com/assets/2585079/20427007/0d1c0282-ad3f-11e6-9447-ef7cb613870b.png)

Also, I've proposed a change to the warning message, changing it to "This website is not a reliable news source."  The idea of a "questionable source" seemed vague.  If I understand the point of the plugin it's to discourage people from treating certain sources as news.

Finally, I changed the declaration of the linkWarning function mostly because my linter was bugging me about having a function declared within an if block.