### PR TITLE
modified newsthump upon request

### DIFF
--- a/chrome/data/data.json
+++ b/chrome/data/data.json
@@ -289,7 +289,7 @@
   {"url": "newsopening.com", "type": ""},
   {"url": "newstarget.com", "type": ""},
   {"url": "newstarget.com", "type": "conspiracy"},
-  {"url": "newsthump.com", "type": ""},
+  {"url": "newsthump.com", "type": "satire"},
   {"url": "newstoad.net", "type": ""},
   {"url": "newswatch28.com", "type": "fake"},
   {"url": "newswatch33.com", "type": "fake"},


### PR DESCRIPTION
Added "satire" tag to newsthump.com after checking site and verifying its content.  Request was made on link dispute ticket.